### PR TITLE
bump pandas version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = { file = "LICENSE" }
 classifiers = ["Development Status :: 4 - Beta", "License :: OSI Approved :: Apache Software License"]
 
 dependencies = [
-    "pandas>=1.4",
+    "pandas>=2.2.0",
     "scikit-learn",
     "transformers[torch]>=4.36.1",
     "datasets"


### PR DESCRIPTION
Bump pandas to a compatible version to address: 
https://github.com/ibm-granite/granite-tsfm/issues/55
