### PR TITLE
fork and fix tsfm_public/version.py

### DIFF
--- a/tsfm_public/version.py
+++ b/tsfm_public/version.py
@@ -6,4 +6,4 @@ try:
     from ._version import __version__, __version_tuple__  # noqa: F401 # unused import
 except ImportError:
     __version__ = "unknown"
-    version_tuple = (0, 0, __version__)
+    __version_tuple__ = (0, 0, __version__)


### PR DESCRIPTION
On cloning the repo and importing TimeSeriesPreprocessor at tsfm_public using
from tsfm_public.toolkit.time_series_preprocessor import TimeSeriesPreprocessor
to create a new data loader, I got the following error

Traceback (most recent call last):
File "/dccstor/iloum-la/expts_notebooks/tsfm/data/new_datasets.py", line 11, in
from tsfm_public.toolkit.time_series_preprocessor import TimeSeriesPreprocessor
File "/dccstor/iloum-la/expts_notebooks/granite-tsfm/tsfm_public/init.py", line 4, in
from .version import version, version_tuple
ImportError: cannot import name 'version_tuple' from 'tsfm_public.version' (/dccstor/iloum-la/expts_notebooks/granite-tsfm/tsfm_public/version.py)

Looks like there is a bug in version.py. Changing the version.py in the below manner resolved the error.

try:
    # Local
    from ._version import __version__, __version_tuple__  # noqa: F401 # unused import
except ImportError:
    __version__ = "unknown"
    version_tuple = (0, 0, __version__) ##### earlier line 
    __version_tuple__ = (0, 0, __version__) #### our change