### PR TITLE
Univariate dataset support

### DIFF
--- a/tests/toolkit/test_time_series_preprocessor.py
+++ b/tests/toolkit/test_time_series_preprocessor.py
@@ -398,7 +398,25 @@ def test_get_datasets_without_targets(ts_data):
 
     train, _, _ = get_datasets(tsp, ts_data, split_config={"train": 0.7, "test": 0.2})
 
-    train.datasets[0].target_columns == ["value1", "value2"]
+    assert train.datasets[0].target_columns == ["value1", "value2"]
+
+
+def test_get_datasets_univariate(ts_data):
+    tsp = TimeSeriesPreprocessor(
+        timestamp_column="timestamp",
+        id_columns=["id", "id2"],
+        target_columns=["value1", "value2"],
+        prediction_length=2,
+        context_length=5,
+    )
+
+    # for baseline
+    train_base, _, _ = get_datasets(tsp, ts_data, split_config={"train": 0.7, "test": 0.2})
+
+    train, _, _ = get_datasets(tsp, ts_data, split_config={"train": 0.7, "test": 0.2}, as_univariate=True)
+
+    assert train[0]["id"][-1] == "value1"
+    assert len(train) == 2 * len(train_base)
 
 
 def test_id_columns_and_scaling_id_columns(ts_data_runs):

--- a/tests/toolkit/test_util.py
+++ b/tests/toolkit/test_util.py
@@ -3,7 +3,7 @@
 import pandas as pd
 import pytest
 
-from tsfm_public.toolkit.util import get_split_params, train_test_split
+from tsfm_public.toolkit.util import convert_to_univariate, get_split_params, train_test_split
 
 
 split_cases = [
@@ -49,3 +49,27 @@ def test_train_test_split():
     assert len(valid) == valid_len_101
 
     assert valid_len_100 + 1 == valid_len_101
+
+
+def test_convert_to_univariate(ts_data):
+    id_columns = ["id"]
+    timestamp_column = "timestamp"
+    target_columns = ["value1", "value2"]
+    df_uni = convert_to_univariate(
+        ts_data, timestamp_column=timestamp_column, id_columns=id_columns, target_columns=target_columns
+    )
+
+    assert df_uni.columns.to_list() == [
+        timestamp_column,
+    ] + id_columns + ["column_id", "value"]
+
+    assert len(df_uni) == len(target_columns) * len(ts_data)
+
+    # test single column
+
+    target_columns = ["value1"]
+
+    with pytest.raises(ValueError):
+        df_uni = convert_to_univariate(
+            ts_data, timestamp_column=timestamp_column, id_columns=id_columns, target_columns=target_columns
+        )

--- a/tsfm_public/toolkit/util.py
+++ b/tsfm_public/toolkit/util.py
@@ -553,15 +553,43 @@ def convert_tsf(filename: str) -> pd.DataFrame:
         contain_equal_length,
     ) = convert_tsf_to_dataframe(filename)
 
+    id_column_name = "id"
+    timestamp_column_name = "timestamp"
+    value_column_name = "value"
+
+    tsf_to_pandas = {
+        "daily": "d",
+        "hourly": "h",
+        "seconds": "s",
+        "minutes": "min",
+        "minutely": "min",
+    }
+
+    print(f"frequency: {frequency}")
+    if frequency:
+        try:
+            freq_val, freq_unit = frequency.split("_")
+            freq = freq_val + tsf_to_pandas[freq_unit]
+        except ValueError:
+            freq = tsf_to_pandas(freq_val)
+        except KeyError:
+            raise ValueError(f"Input file contains an unknow frequency unit {freq_unit}")
+    else:
+        freq = None
+
     dfs = []
     for index, item in loaded_data.iterrows():
-        # todo: use actual dates for timestamp
+        if freq:
+            timestamps = pd.date_range(item.start_timestamp, periods=len(item.series_value), freq=freq)
+        else:
+            timestamps = range(len(item.series_value))
+
         dfs.append(
             pd.DataFrame(
                 {
-                    "id": item.series_name,
-                    "timestamp": range(len(item.series_value)),
-                    "value": item.series_value,
+                    id_column_name: item.series_name,
+                    timestamp_column_name: timestamps,
+                    value_column_name: item.series_value,
                 }
             )
         )

--- a/tsfm_public/toolkit/util.py
+++ b/tsfm_public/toolkit/util.py
@@ -537,7 +537,9 @@ def get_split_params(
 
 def convert_tsf(filename: str) -> pd.DataFrame:
     """Converts a tsf format file into a pandas dataframe.
-    Returns the result in canonical multi-time series format, with an ID column, and timestamp.
+    Returns the result in canonical multi-time series format, with an ID column, timestamp, and one or more
+    value columns. Attemps to map frequency information given in the input file to pandas equivalents.
+
 
     Args:
         filename (str): Input file name.
@@ -557,7 +559,7 @@ def convert_tsf(filename: str) -> pd.DataFrame:
     timestamp_column_name = "timestamp"
     value_column_name = "value"
 
-    tsf_to_pandas = {
+    tsf_to_pandas_freq_map = {
         "daily": "d",
         "hourly": "h",
         "seconds": "s",
@@ -565,13 +567,12 @@ def convert_tsf(filename: str) -> pd.DataFrame:
         "minutely": "min",
     }
 
-    print(f"frequency: {frequency}")
     if frequency:
         try:
             freq_val, freq_unit = frequency.split("_")
-            freq = freq_val + tsf_to_pandas[freq_unit]
+            freq = freq_val + tsf_to_pandas_freq_map[freq_unit]
         except ValueError:
-            freq = tsf_to_pandas(freq_val)
+            freq = tsf_to_pandas_freq_map(freq_val)
         except KeyError:
             raise ValueError(f"Input file contains an unknow frequency unit {freq_unit}")
     else:
@@ -607,7 +608,7 @@ def convert_to_univariate(
     value_name: str = "value",
 ) -> pd.DataFrame:
     """Converts a dataframe in canonical format to a univariate dataset. Adds an additional id column to
-    indicate which of the original target columns to which the value corresponds.
+    indicate the original target column to which a given value corresponds.
 
     Args:
         data (pd.DataFrame): Input data frame containing multiple target columns.

--- a/tsfm_public/toolkit/util.py
+++ b/tsfm_public/toolkit/util.py
@@ -598,6 +598,45 @@ def convert_tsf(filename: str) -> pd.DataFrame:
     return df
 
 
+def convert_to_univariate(
+    data: pd.DataFrame,
+    timestamp_column: str,
+    id_columns: List[str],
+    target_columns: List[str],
+    var_name: str = "column_id",
+    value_name: str = "value",
+) -> pd.DataFrame:
+    """Converts a dataframe in canonical format to a univariate dataset. Adds an additional id column to
+    indicate which of the original target columns to which the value corresponds.
+
+    Args:
+        data (pd.DataFrame): Input data frame containing multiple target columns.
+        timestamp_column (str): String representing the timestamp column.
+        id_columns (List[str]): List of columns representing the ids in the data. Use empty list (`[]`) if there
+            are no id columns.
+        target_columns (List[str]): The target columns in the data.
+        var_name (str): Name of new id column used to identify original column name. Defaults to "column_id".
+        value_name (str): Name of new value column in the resulting univariate datset. Defaults to "value".
+
+    Returns:
+        pd.DataFrame: Converted dataframe.
+    """
+
+    if len(target_columns) < 2:
+        raise ValueError("`target_columns` should be a non-empty list of two or more elements.")
+
+    return pd.melt(
+        data,
+        id_vars=[
+            timestamp_column,
+        ]
+        + id_columns,
+        value_vars=target_columns,
+        var_name=var_name,
+        value_name=value_name,
+    )
+
+
 def join_list_without_repeat(*lists: List[List[Any]]) -> List[Any]:
     """Join multiple lists in sequence without repeating
 


### PR DESCRIPTION
Add support to create univariate torch datasets from multivariate inputs for the purpose of channel independent pretraining.