### PR TITLE
Limit numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "transformers[torch]>=4.36.1",
     "datasets",
     "deprecated",
-    "urllib3>=2.2.2"
+    "urllib3>=2.2.2",
+    "numpy<2"
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
Limit numpy < 2, to resolve some issues with transformers library.