### PR TITLE
Limit urllib3 <2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "transformers[torch]>=4.36.1",
     "datasets",
     "deprecated",
-    "urllib3>=2.2.2",
+    "urllib3>=1.26.19,urllib3<2",
     "numpy<2"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "transformers[torch]>=4.36.1",
     "datasets",
     "deprecated",
-    "urllib3>=1.26.19,urllib3<2",
+    "urllib3>=1.26.19,<2",
     "numpy<2"
 ]
 


### PR DESCRIPTION
Transformers has a dependency of `"urllib3<2.0.0",`.

This PR ensures we don't violate that requirement, while still satisfying: https://www.mend.io/vulnerability-database/CVE-2024-37891