### PR TITLE
bump transformers version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = ["Development Status :: 4 - Beta", "License :: OSI Approved :: Apa
 dependencies = [
     "pandas>=2.2.0",
     "scikit-learn",
-    "transformers[torch]>=4.36.1",
+    "transformers[torch]>=4.38.0",
     "datasets",
     "deprecated",
     "urllib3>=1.26.19,<2",


### PR DESCRIPTION
Handle issue with ` build_pipeline_init_args` which became available only after 4.38.0