### PR TITLE
:Revert "extend to 3.12 for service runtime too"

### DIFF
--- a/.github/workflows/inference-services-test.yml
+++ b/.github/workflows/inference-services-test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/services/inference/pyproject.toml
+++ b/services/inference/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{ include = "tsfminference/**/*.py" }]
 
 [tool.poetry.dependencies]
 # including 3.9 causes poetry lock to run forever
-python = ">=3.10,<3.13"
+python = ">=3.10,<3.12"
 numpy = { version = "<2" }
 tsfm_public = { git = "https://github.com/IBM/tsfm.git", tag = "v0.2.5" }
 


### PR DESCRIPTION
This reverts commit 29cc2a8ab53bb955fd426c16873c86c9f6ea3d2b.

Await new release of core component first.