### PR TITLE
Avoid distutils due to deprecation

### DIFF
--- a/tsfm_public/toolkit/util.py
+++ b/tsfm_public/toolkit/util.py
@@ -5,12 +5,29 @@
 import copy
 import enum
 from datetime import datetime
-from distutils.util import strtobool
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
 import torch
+
+
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+
+    Source: setuptools/_distutils/util.py
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    else:
+        raise ValueError(f"invalid truth value {val!r}")
 
 
 class FractionLocation(enum.Enum):


### PR DESCRIPTION
Use an implementation of strtobool instead of importing from distutils.

Addresses https://github.com/ibm-granite/granite-tsfm/issues/118