### PR TITLE
Tsfm model dir

### DIFF
--- a/services/inference/Makefile
+++ b/services/inference/Makefile
@@ -22,6 +22,15 @@ image: boilerplate
 start_service_image: image
 	$(CONTAINER_BUILDER) run -p 8000:8000 -d --rm --name tsfmserver tsfminference
 	sleep 10
+
+start_service_image_no_hf: image
+	$(CONTAINER_BUILDER) run -p 8000:8000 \
+	  -e "TSFM_ALLOW_LOAD_FROM_HF_HUB=0" \
+	  -e "TSFM_MODEL_DIR=/" \
+	  -v ./ibm:/ibm \
+	  --rm --name tsfmserver tsfminference
+	sleep 10
+
 stop_service_image:
 	$(CONTAINER_BUILDER) stop tsfmserver
 

--- a/services/inference/tsfminference/__init__.py
+++ b/services/inference/tsfminference/__init__.py
@@ -2,6 +2,8 @@
 #
 import logging
 import os
+import tempfile
+from pathlib import Path
 
 from .version import __version__, __version_tuple__
 
@@ -34,3 +36,9 @@ TSFM_CONFIG_FILE = os.getenv(
     "TSFM_CONFIG_FILE",
     os.path.realpath(os.path.join(os.path.dirname(__file__), "default_config.yml")),
 )
+
+# use TSFM_MODEL_DIR preferentially. If not set, use HF_HOME or the system tempdir if that's not set.
+TSFM_MODEL_DIR: Path = Path(os.environ.get("TSFM_MODEL_DIR", os.environ.get("HF_HOME", tempfile.gettempdir())))
+
+if not TSFM_MODEL_DIR.exists():
+    raise Exception(f"TSFM_MODEL_DIR {TSFM_MODEL_DIR} does not exist.")

--- a/services/inference/tsfminference/default_config.yml
+++ b/services/inference/tsfminference/default_config.yml
@@ -4,5 +4,3 @@ custom_modules:
     model_type: tinytimemixer
     model_config_name: TinyTimeMixerConfig
 
-# path where local models will be loaded from
-model_dir: /Users/wmgifford/Downloads/

--- a/services/inference/tsfminference/inference.py
+++ b/services/inference/tsfminference/inference.py
@@ -4,7 +4,6 @@
 
 import datetime
 import logging
-from pathlib import Path
 from typing import Any, Dict, List
 
 import pandas as pd
@@ -12,7 +11,7 @@ from fastapi import APIRouter, HTTPException
 
 from tsfm_public import TimeSeriesForecastingPipeline, TimeSeriesPreprocessor
 
-from . import TSFM_ALLOW_LOAD_FROM_HF_HUB
+from . import TSFM_ALLOW_LOAD_FROM_HF_HUB, TSFM_MODEL_DIR
 from .constants import API_VERSION
 from .hfutil import load_config, load_model, register_config
 from .inference_payloads import ForecastingInferenceInput, PredictOutput
@@ -87,7 +86,7 @@ class InferenceRuntime:
         data = decode_data(input_payload.data, input_payload.schema)
         future_data = decode_data(input_payload.future_data, input_payload.schema)
 
-        model_path = Path(self.config["model_dir"]) / input_payload.model_id
+        model_path = TSFM_MODEL_DIR / input_payload.model_id
 
         if not model_path.is_dir():
             LOGGER.info(f"Could not find model at path: {model_path}")
@@ -96,7 +95,7 @@ class InferenceRuntime:
                 LOGGER.info(f"Using HuggingFace Hub: {model_path}")
             else:
                 raise RuntimeError(
-                    f"Could not load model {input_payload.model_id} from {self.config['model_dir']}. If trying to load directly from the HuggingFace Hub please ensure that `TSFM_ALLOW_LOAD_FROM_HF_HUB=1`"
+                    f"Could not load model {input_payload.model_id} from {TSFM_MODEL_DIR.as_posix()}. If trying to load directly from the HuggingFace Hub please ensure that `TSFM_ALLOW_LOAD_FROM_HF_HUB=1`"
                 )
 
         model, preprocessor = self.load(model_path)

--- a/services/inference/tsfminference/main.py
+++ b/services/inference/tsfminference/main.py
@@ -11,6 +11,7 @@ from fastapi.responses import RedirectResponse
 
 from . import (
     TSFM_CONFIG_FILE,
+    TSFM_MODEL_DIR,
     TSFM_PYTHON_LOGGING_FORMAT,
     TSFM_PYTHON_LOGGING_LEVEL,
 )
@@ -23,6 +24,7 @@ logging.basicConfig(
     level=TSFM_PYTHON_LOGGING_LEVEL,
 )
 
+logging.info(f"Using TSFM_MODEL_DIR {TSFM_MODEL_DIR}")
 
 if TSFM_CONFIG_FILE:
     with open(TSFM_CONFIG_FILE, "r") as file:


### PR DESCRIPTION
This moves the `model_dir` out of the configuration file and sets it via the environment variable `TSFM_MODEL_DIR`

The behavior is as follows:

* TSFM_MODEL_DIR set to what runtime sees in the environment
* If the above is not set, TSFM_MODEL_DIR will be set to the HF_HOME env var;
* If HF_HOME is not set, then TSFM_MODEL_DIR will default to the system temp directory
* If the resulting TSFM_MODEL_DIR is not present, the runtime will not start (we raise an Exception).