### PR TITLE
Improve inference error checks

### DIFF
--- a/services/inference/tests/test_inference_lib.py
+++ b/services/inference/tests/test_inference_lib.py
@@ -28,7 +28,7 @@ MODEL_ID = "mytest-tsfm/ttm-r1"
 def ts_data_base() -> pd.DataFrame:
     # Generate a date range
     length = SERIES_LENGTH
-    date_range = pd.date_range(start="2023-10-01", periods=length, freq="H")
+    date_range = pd.date_range(start="2023-10-01", periods=length, freq="h")
 
     # Create a DataFrame
     df = pd.DataFrame(

--- a/services/inference/tests/test_inference_service.py
+++ b/services/inference/tests/test_inference_service.py
@@ -16,6 +16,7 @@ model_param_map = {
     "ttm-1024-96-r1": {"context_length": 1024, "prediction_length": 96},
     "ttm-r2": {"context_length": 512, "prediction_length": 96},
     "ttm-r2-etth-finetuned": {"context_length": 512, "prediction_length": 96},
+    "ttm-r2-etth-finetuned-control": {"context_length": 512, "prediction_length": 96},
     "ttm-1024-96-r2": {"context_length": 1024, "prediction_length": 96},
     "ttm-1536-96-r2": {"context_length": 1536, "prediction_length": 96},
     "ibm/test-patchtst": {"context_length": 512, "prediction_length": 96},
@@ -361,7 +362,7 @@ def test_zero_shot_forecast_inference(ts_data):
     assert counts["output_data_points"] == (prediction_length // 4) * len(params["target_columns"][1:])
 
 
-@pytest.mark.parametrize("ts_data", ["ttm-r2"], indirect=True)
+@pytest.mark.parametrize("ts_data", ["ttm-r2-etth-finetuned-control"], indirect=True)
 def test_future_data_forecast_inference(ts_data):
     test_data, params = ts_data
 
@@ -400,6 +401,7 @@ def test_future_data_forecast_inference(ts_data):
             "id_columns": params["id_columns"],
             "target_columns": target_columns,
             "control_columns": [c for c in params["target_columns"] if c not in target_columns],
+            "freq": "1h",
         },
         "data": encode_data(test_data_, params["timestamp_column"]),
         "future_data": encode_data(future_data, params["timestamp_column"]),
@@ -409,8 +411,10 @@ def test_future_data_forecast_inference(ts_data):
         "Future data should have time series of length that is at least the specified prediction length." in out.text
     )
 
-    # test multi series, longer future data
-    test_data_ = test_data.copy()
+    # test single series, longer future data
+    test_data_ = test_data[test_data[id_columns[0]] == "a"].copy()
+    num_ids = 1
+    # test_data_ = test_data.copy()
 
     target_columns = ["OT"]
 
@@ -435,6 +439,7 @@ def test_future_data_forecast_inference(ts_data):
             "id_columns": params["id_columns"],
             "target_columns": target_columns,
             "control_columns": [c for c in params["target_columns"] if c not in target_columns],
+            "freq": "1h",
         },
         "data": encode_data(test_data_, params["timestamp_column"]),
         "future_data": encode_data(future_data, params["timestamp_column"]),

--- a/services/inference/tsfminference/tsfm_config.py
+++ b/services/inference/tsfminference/tsfm_config.py
@@ -57,6 +57,7 @@ class TSFMConfig(PushToHubMixin):
         self.minimum_context_length = kwargs.pop("minimum_context_length", 1)
         self.maximum_context_length = kwargs.pop("maximum_context_length", None)
         self.maximum_prediction_length = kwargs.pop("maximum_prediction_length", None)
+        self.is_finetuned = kwargs.pop("is_finetuned", False)
 
         # "maximum_prediction_length": 96,
         # "minimum_context_length": 512,


### PR DESCRIPTION
Add is_finetuned to the tsfm_config.json to be used to indicate that a serialized model is fine-tuned

Improve error checks: 
- check that a preprocessor exists if the model is fine-tuned
- check that there is no future_data provided if it is not needed
- check that additional columns are provided only when the model can handle it