### PR TITLE
support [] as scaling id columns

### DIFF
--- a/tests/toolkit/test_time_series_preprocessor.py
+++ b/tests/toolkit/test_time_series_preprocessor.py
@@ -599,9 +599,39 @@ def test_id_columns_and_scaling_id_columns(ts_data_runs):
         scaling=True,
     )
 
-    ds_train, ds_valid, ds_test = get_datasets(tsp, df, split_config={"train": 0.7, "test": 0.2})
+    ds_train, _, _ = get_datasets(tsp, df, split_config={"train": 0.7, "test": 0.2})
 
     assert len(tsp.target_scaler_dict) == 2
+    assert len(ds_train.datasets) == 4
+
+    tsp = TimeSeriesPreprocessor(
+        timestamp_column="timestamp",
+        prediction_length=2,
+        context_length=5,
+        id_columns=["asset_id", "run_id"],
+        scaling_id_columns=[],
+        target_columns=["value1"],
+        scaling=True,
+    )
+
+    ds_train, _, _ = get_datasets(tsp, df, split_config={"train": 0.7, "test": 0.2})
+
+    assert len(tsp.target_scaler_dict) == 1
+    assert len(ds_train.datasets) == 4
+
+    tsp = TimeSeriesPreprocessor(
+        timestamp_column="timestamp",
+        prediction_length=2,
+        context_length=5,
+        id_columns=["asset_id", "run_id"],
+        scaling_id_columns=None,
+        target_columns=["value1"],
+        scaling=True,
+    )
+
+    ds_train, _, _ = get_datasets(tsp, df, split_config={"train": 0.7, "test": 0.2})
+
+    assert len(tsp.target_scaler_dict) == 4
     assert len(ds_train.datasets) == 4
 
 


### PR DESCRIPTION
Allows passing [] in scaling_id_columns. The options for training separate scalers are the following:

Assumptions: a dataset with the available id columns `["id_1", "id_2", "id_3]`
1) If `id_columns = ["id_1", "id_2"]`, `scaling_id_columns = None`: divide data into groups determined by the unique combinations of `["id_1", "id_2"]` and train separate scalers on each group.
2) If `id_columns = ["id_1", "id_2", "id_3"]`, `scaling_id_columns =["id_3"]`: divide data into groups determined by the unique combinations of `["id_3"]` and train separate scalers on each group.
3) If `id_columns = ["id_1", "id_2", "id_3"]`, `scaling_id_columns =[]`: treat data as a single group, only one scaler is trained.
4) If `id_columns = ["id_1", "id_2"]`, `scaling_id_columns =["id_3"]`: error. The `scaling_id_columns` should be a subset of `id_columns`.