### PR TITLE
Service missing config + support quality

### DIFF
--- a/services/boilerplate/tsfm_config.py
+++ b/services/boilerplate/tsfm_config.py
@@ -42,6 +42,7 @@ class TSFMConfig(PushToHubMixin):
             no maximum. Defaults to None.
         inference_batch_size (int, optional): Size of batch to construct when performing inference. Defaults to 16.
         is_finetuned (bool, optional): Indicates that the model has been finetuned. Defaults to False.
+        extra_pipeline_arguments (dict, optional): Additional arguments that get passed during service operations. Defaults to {}.
 
     Notes:
         If module_path, model_type, model_config_name, model_class_name are absent, and the HFServiceHandler is used, the
@@ -66,6 +67,7 @@ class TSFMConfig(PushToHubMixin):
         self.maximum_prediction_length = kwargs.pop("maximum_prediction_length", None)
         self.is_finetuned = kwargs.pop("is_finetuned", False)
         self.inference_batch_size = kwargs.pop("inference_batch_size", 16)
+        self.extra_pipeline_arguments = kwargs.pop("extra_pipeline_arguments", {})
 
         # "maximum_prediction_length": 96,
         # "minimum_context_length": 512,

--- a/services/boilerplate/tsfm_util.py
+++ b/services/boilerplate/tsfm_util.py
@@ -13,6 +13,7 @@ from transformers import (
     PreTrainedModel,
 )
 
+import tsfm_public
 from tsfm_public.toolkit.hf_util import register_config
 
 

--- a/services/boilerplate/tsfm_util.py
+++ b/services/boilerplate/tsfm_util.py
@@ -14,10 +14,45 @@ from transformers import (
 )
 
 import tsfm_public
-from tsfm_public.toolkit.hf_util import register_config
 
 
 LOGGER = logging.getLogger(__file__)
+
+
+try:
+    from tsfm_public.toolkit.hf_util import register_config
+
+except ImportError:
+
+    def register_config(model_type: str, model_config_name: str, module_path: str) -> None:
+        """Register a configuration for a particular model architecture
+
+        Args:
+            model_type (Optional[str], optional): The type of the model, from the model implementation. Defaults to None.
+            model_config_name (Optional[str], optional): The name of configuration class for the model. Defaults to None.
+            module_path (Optional[str], optional): Python module path that can be used to load the
+                config/model. Defaults to None.
+
+        Raises:
+            RuntimeError: Raised when the module cannot be imported from the provided module path.
+        """
+        # example
+        # model_type: "tinytimemixer"
+        # model_config_name: "TinyTimeMixerConfig"
+        # module_path: "tsfm"  # place where config should be importable
+
+        # AutoConfig.register("tinytimemixer", TinyTimeMixerConfig)
+        try:
+            mod = importlib.import_module(module_path)
+            conf_class = getattr(mod, model_config_name, None)
+        except ModuleNotFoundError as exc:  # modulenot found, key error ?
+            raise RuntimeError(f"Could not load {model_config_name} from {module_path}") from exc
+
+        if conf_class is not None:
+            AutoConfig.register(model_type, conf_class)
+        else:
+            # issue warning?
+            pass
 
 
 def load_config(

--- a/services/boilerplate/tsfm_util.py
+++ b/services/boilerplate/tsfm_util.py
@@ -13,41 +13,10 @@ from transformers import (
     PreTrainedModel,
 )
 
-import tsfm_public
+from tsfm_public.toolkit.hf_util import register_config
 
 
 LOGGER = logging.getLogger(__file__)
-
-
-def register_config(model_type: str, model_config_name: str, module_path: str) -> None:
-    """Register a configuration for a particular model architecture
-
-    Args:
-        model_type (Optional[str], optional): The type of the model, from the model implementation. Defaults to None.
-        model_config_name (Optional[str], optional): The name of configuration class for the model. Defaults to None.
-        module_path (Optional[str], optional): Python module path that can be used to load the
-            config/model. Defaults to None.
-
-    Raises:
-        RuntimeError: Raised when the module cannot be imported from the provided module path.
-    """
-    # example
-    # model_type: "tinytimemixer"
-    # model_config_name: "TinyTimeMixerConfig"
-    # module_path: "tsfm"  # place where config should be importable
-
-    # AutoConfig.register("tinytimemixer", TinyTimeMixerConfig)
-    try:
-        mod = importlib.import_module(module_path)
-        conf_class = getattr(mod, model_config_name, None)
-    except ModuleNotFoundError as exc:  # modulenot found, key error ?
-        raise RuntimeError(f"Could not load {model_config_name} from {module_path}") from exc
-
-    if conf_class is not None:
-        AutoConfig.register(model_type, conf_class)
-    else:
-        # issue warning?
-        pass
 
 
 def load_config(

--- a/services/inference/tests/test_inference_service.py
+++ b/services/inference/tests/test_inference_service.py
@@ -479,7 +479,6 @@ def test_forecast_inference_with_impute(ts_data):
     test_data, params = ts_data
 
     prediction_length = params["prediction_length"]
-    context_length = params["context_length"]
     model_id = params["model_id"]
     model_id_path: str = model_id
 

--- a/services/inference/tests/test_inference_service.py
+++ b/services/inference/tests/test_inference_service.py
@@ -1,6 +1,7 @@
 # Copyright contributors to the TSFM project
 #
 import os
+from math import isnan
 from typing import Any, Dict
 
 import numpy as np
@@ -22,6 +23,7 @@ model_param_map = {
     "ttm-1536-96-r2": {"context_length": 1536, "prediction_length": 96},
     "ibm/test-patchtst": {"context_length": 512, "prediction_length": 96},
     "ibm/test-patchtsmixer": {"context_length": 512, "prediction_length": 96},
+    "ttm-r2-etth-finetuned-impute": {"context_length": 512, "prediction_length": 96},
 }
 
 
@@ -94,6 +96,13 @@ def encode_data(df: pd.DataFrame, timestamp_column: str) -> Dict[str, Any]:
     if pd.api.types.is_datetime64_dtype(df[timestamp_column]):
         df[timestamp_column] = df[timestamp_column].apply(lambda x: x.isoformat())
     data_payload = df.to_dict(orient="list")
+
+    for k, v in data_payload.items():
+        if isinstance(v[0], str):
+            continue
+        # rewrite all the nan to None
+        data_payload[k] = [vv if (vv is None) or (not isnan(vv)) else None for vv in v]
+
     return data_payload
 
 
@@ -462,6 +471,60 @@ def test_future_data_forecast_inference(ts_data):
         * num_ids
     )
     assert counts["output_data_points"] == prediction_length * 1 * num_ids
+
+
+@pytest.mark.skip(reason="Will re-enable once updated tsfm_public is available.")
+@pytest.mark.parametrize("ts_data", ["ttm-r2-etth-finetuned-impute"], indirect=True)
+def test_forecast_inference_with_impute(ts_data):
+    test_data, params = ts_data
+
+    prediction_length = params["prediction_length"]
+    context_length = params["context_length"]
+    model_id = params["model_id"]
+    model_id_path: str = model_id
+
+    id_columns = params["id_columns"]
+
+    # test single series, longer future data
+    test_data_ = test_data[test_data[id_columns[0]] == "a"].copy()
+
+    num_ids = 1
+
+    target_columns = ["OT"]
+    mask = np.random.rand(len(test_data_)) < 0.1
+    test_data_.loc[mask, target_columns[0]] = np.nan
+
+    future_data = extend_time_series(
+        select_by_index(test_data_, id_columns=params["id_columns"], start_index=-1),
+        timestamp_column=params["timestamp_column"],
+        grouping_columns=params["id_columns"],
+        total_periods=20,
+        freq="1h",
+    )
+    future_data = future_data.fillna(0)
+
+    prediction_length = 20
+
+    msg = {
+        "model_id": model_id_path,
+        "parameters": {
+            "prediction_length": prediction_length,
+        },
+        "schema": {
+            "timestamp_column": params["timestamp_column"],
+            "id_columns": params["id_columns"],
+            "target_columns": target_columns,
+            "control_columns": [c for c in params["target_columns"] if c not in target_columns],
+            "freq": "1h",
+        },
+        "data": encode_data(test_data_, params["timestamp_column"]),
+        "future_data": encode_data(future_data, params["timestamp_column"]),
+    }
+
+    df_out, counts = get_inference_response(msg)
+
+    assert len(df_out) == 1
+    assert df_out[0].shape[0] == prediction_length * num_ids
 
 
 @pytest.mark.parametrize(

--- a/services/inference/tsfminference/tsfm_inference_handler.py
+++ b/services/inference/tsfminference/tsfm_inference_handler.py
@@ -283,6 +283,8 @@ class TSFMForecastingInferenceHandler:
         LOGGER.info(f"Using inference batch size: {batch_size}")
 
         device = "cpu" if not torch.cuda.is_available() else "cuda"
+
+        extra_pipeline_args = getattr(self.handler_config, "extra_pipeline_arguments", {})
         forecast_pipeline = TimeSeriesForecastingPipeline(
             model=self.model,
             explode_forecasts=True,
@@ -291,6 +293,7 @@ class TSFMForecastingInferenceHandler:
             freq=self.preprocessor.freq,
             device=device,
             batch_size=1000,
+            **extra_pipeline_args,
         )
         forecasts = forecast_pipeline(data, future_time_series=future_data, inverse_scale_outputs=True)
 

--- a/tsfm_public/__init__.py
+++ b/tsfm_public/__init__.py
@@ -107,3 +107,10 @@ else:
         module_spec=__spec__,
         extra_objects={"__version__": __version__},
     )
+
+
+# regiset local models now
+from tsfm_public.toolkit.hf_util import register_config
+
+
+register_config(model_type="tinytimemixer", model_config_name="TinyTimeMixerConfig", module_path="tsfm_public")

--- a/tsfm_public/__init__.py
+++ b/tsfm_public/__init__.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 # Check the dependencies satisfy the minimal versions required.
 from transformers.utils import _LazyModule
 
+from tsfm_public.toolkit.hf_util import register_config
+
 from .version import __version__, __version_tuple__
 
 
@@ -109,8 +111,5 @@ else:
     )
 
 
-# regiset local models now
-from tsfm_public.toolkit.hf_util import register_config
-
-
+# register local models now
 register_config(model_type="tinytimemixer", model_config_name="TinyTimeMixerConfig", module_path="tsfm_public")

--- a/tsfm_public/toolkit/dataset.py
+++ b/tsfm_public/toolkit/dataset.py
@@ -479,6 +479,13 @@ class ForecastDFDataset(BaseConcatDFDataset):
     ):
         # output_columns_tmp = input_columns if output_columns == [] else output_columns
 
+        if not (
+            impute_method is None
+            or impute_method == ImputeMethod.FORWARD_FILL.value
+            or impute_method == ImputeMethod.LINEAR.value
+        ):
+            raise ValueError(f"Unknown impute_method {self.impute_method}.")
+
         super().__init__(
             data_df=data,
             id_columns=id_columns,
@@ -610,6 +617,8 @@ class ForecastDFDataset(BaseConcatDFDataset):
                 seq_x_imputed = np.apply_along_axis(interpolate_by_var, 0, seq_x)
             elif self.impute_method is None:
                 seq_x_imputed = np.nan_to_num(seq_x, nan=self.fill_value)
+            else:
+                raise ValueError(f"Unknown impute_method {self.impute_method}.")
 
             # seq_y: batch_size x pred_len x num_x_cols
             seq_y = self.y.iloc[

--- a/tsfm_public/toolkit/hf_util.py
+++ b/tsfm_public/toolkit/hf_util.py
@@ -31,5 +31,4 @@ def register_config(model_type: str, model_config_name: str, module_path: str) -
     if conf_class is not None:
         AutoConfig.register(model_type, conf_class)
     else:
-        # issue warning?
-        pass
+        raise RuntimeError(f"Could not find {model_config_name}")

--- a/tsfm_public/toolkit/hf_util.py
+++ b/tsfm_public/toolkit/hf_util.py
@@ -1,0 +1,35 @@
+"""Miscellaneous utilities for huggingface transformers"""
+
+import importlib
+
+from transformers import AutoConfig
+
+
+def register_config(model_type: str, model_config_name: str, module_path: str) -> None:
+    """Register a configuration for a particular model architecture
+
+    Args:
+        model_type (Optional[str], optional): The type of the model, from the model implementation. Defaults to None.
+        model_config_name (Optional[str], optional): The name of configuration class for the model. Defaults to None.
+        module_path (Optional[str], optional): Python module path that can be used to load the
+            config/model. Defaults to None.
+
+    Raises:
+        RuntimeError: Raised when the module cannot be imported from the provided module path.
+    """
+    # example
+    # model_type: "tinytimemixer"
+    # model_config_name: "TinyTimeMixerConfig"
+    # module_path: "tsfm"  # place where config should be importable
+
+    try:
+        mod = importlib.import_module(module_path)
+        conf_class = getattr(mod, model_config_name, None)
+    except ModuleNotFoundError as exc:  # modulenot found, key error ?
+        raise RuntimeError(f"Could not load {model_config_name} from {module_path}") from exc
+
+    if conf_class is not None:
+        AutoConfig.register(model_type, conf_class)
+    else:
+        # issue warning?
+        pass

--- a/tsfm_public/toolkit/hf_util.py
+++ b/tsfm_public/toolkit/hf_util.py
@@ -31,5 +31,4 @@ def register_config(model_type: str, model_config_name: str, module_path: str) -
     if conf_class is not None:
         AutoConfig.register(model_type, conf_class)
     else:
-        # issue warning?
-        pass
+        raise RuntimeError(f"Could not find config for {model_config_name}")

--- a/tsfm_public/toolkit/hf_util.py
+++ b/tsfm_public/toolkit/hf_util.py
@@ -31,4 +31,5 @@ def register_config(model_type: str, model_config_name: str, module_path: str) -
     if conf_class is not None:
         AutoConfig.register(model_type, conf_class)
     else:
-        raise RuntimeError(f"Could not find {model_config_name}")
+        # issue warning?
+        pass

--- a/tsfm_public/toolkit/time_series_forecasting_pipeline.py
+++ b/tsfm_public/toolkit/time_series_forecasting_pipeline.py
@@ -191,6 +191,7 @@ class TimeSeriesForecastingPipeline(TimeSeriesPipeline):
             "categorical_columns",
             "static_categorical_columns",
             "future_time_series",
+            "impute_method",
         ]
         postprocess_params = [
             "prediction_length",


### PR DESCRIPTION
Handle case when `tsfm_config.json` (services handler config) is missing.
Assumptions:
- If no config is provided, the model architecture code is available in either transformers or tsfm_public
- The order in which those libraries are checked is 1) transformers and then 2) tsfm_public. If you have a custom library that provides an inference handler for your custom model, the assumption is that you will provide a `tsfm_config.json`
- When no `tsfm_config.json` is provided, the default handler will be used.

To enable the above, we need to pre-register the config for models in `tsfm_public` (whose implementation is available there).


**work in progress**