### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ibm-granite/granite-tsfm/security/code-scanning/5](https://github.com/ibm-granite/granite-tsfm/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only needs to read repository contents (e.g., to install dependencies and run tests), we will set `contents: read`. This ensures that the `GITHUB_TOKEN` has the least privilege necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
