### PR TITLE
remove hardcoded relative path in lr_finder.py

### DIFF
--- a/services/finetuning/Makefile
+++ b/services/finetuning/Makefile
@@ -20,6 +20,7 @@ image: boilerplate
 	-f Dockerfile.gpu .
 
 clone_models:
+	rm -rf mytest-tsfm || true
 	git lfs install || true
 	git clone -b refactor_v2 https://huggingface.co/ibm-research/test-tsfm mytest-tsfm || true
 

--- a/tsfm_public/toolkit/lr_finder.py
+++ b/tsfm_public/toolkit/lr_finder.py
@@ -4,6 +4,7 @@
 
 import inspect
 import os
+import tempfile
 import uuid
 from cmath import inf
 from pathlib import Path
@@ -187,7 +188,7 @@ class LRFinder:
 
         # save model to load back after fitting
         uid = uuid.uuid4().hex
-        self.temp_path = self.save("current_{}".format(uid), "temp", with_opt=False)
+        self.temp_path = self.save(f"current_{uid}", tempfile.gettempdir(), with_opt=False)
         # set base_lr for the optimizer
         self.set_lr(self.start_lr)
 


### PR DESCRIPTION
 Use of relative path "temp" creates issues with service image that doesn't necessarily have write access to PWD. It also accumulates files in local directories instead of auto-cleaned temporary directory