### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/inference-services-test.yml
+++ b/.github/workflows/inference-services-test.yml
@@ -3,6 +3,9 @@
 
 name: Tsfminference Service Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main", "destiny", "destiny_patches" ]


### PR DESCRIPTION
Potential fix for [https://github.com/ibm-granite/granite-tsfm/security/code-scanning/3](https://github.com/ibm-granite/granite-tsfm/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily reads repository contents and does not perform write operations, the `contents: read` permission is sufficient.

The `permissions` block can be added at the root level of the workflow to apply to all jobs. This ensures consistency and avoids the need to define permissions for each job individually.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
