### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/finetuning-service-test.yml
+++ b/.github/workflows/finetuning-service-test.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: tsfmfinetuning Service Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ibm-granite/granite-tsfm/security/code-scanning/1](https://github.com/ibm-granite/granite-tsfm/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions required for the workflow. Based on the provided workflow, it appears that the workflow only needs to read the repository contents and does not require any write permissions. Therefore, we will set `contents: read` as the minimal permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
