### PR TITLE
Fix outdated install command in finetuning notebook (renamed to granite-tsfm in 6ca6017)

### DIFF
--- a/notebooks/tutorial/ttm_channel_mix_finetuning.ipynb
+++ b/notebooks/tutorial/ttm_channel_mix_finetuning.ipynb
@@ -39,13 +39,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "5f120eaa",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Install the tsfm library\n",
-    "# ! pip install \"tsfm_public[notebooks] @ git+ssh://git@github.com/ibm-granite/granite-tsfm.git\""
+    "# ! pip install \"granite-tsfm[notebooks] @ git+ssh://git@github.com/ibm-granite/granite-tsfm.git\""
    ]
   },
   {


### PR DESCRIPTION
### Context
In commit 6ca6017 the project was renamed from `tsfm_public` to `granite-tsfm` in `pyproject.toml`.  
However, the mix channels finetuning tutorial notebook still referenced the old package name `tsfm_public` in the installation command, which caused pip errors such as:

`ERROR: Could not find a version that satisfies the requirement tsfm-public (unavailable) (from versions: none)
ERROR: No matching distribution found for tsfm-public (unavailable)`


### What this PR changes
- Updated the pip install command to use the correct package name:
  ```bash
  pip install "granite-tsfm[notebooks] @ git+https://github.com/ibm-granite/granite-tsfm.git"
