### PR TITLE
 fix: restore scaler attributes as numpy arrays to support scikit-learn >= 1.8.0

### DIFF
--- a/tsfm_public/toolkit/time_series_preprocessor.py
+++ b/tsfm_public/toolkit/time_series_preprocessor.py
@@ -75,6 +75,13 @@ class SKLearnFeatureExtractionBase:
         """ """
 
         t = cls()
+        # Scikit-learn >= 1.8.0 requires scaler attributes to be numpy arrays (using .astype())
+        # which deserializing from JSON natively parses as Python lists. Let's remap them.
+        import numpy as np
+        for k, v in feature_extractor_dict.items():
+            if isinstance(v, list) and k in ['mean_', 'scale_', 'var_', 'data_min_', 'data_max_', 'data_range_']:
+                feature_extractor_dict[k] = np.array(v)
+
         t.__setstate__(feature_extractor_dict)
 
         return t

--- a/tsfm_public/toolkit/time_series_preprocessor.py
+++ b/tsfm_public/toolkit/time_series_preprocessor.py
@@ -78,8 +78,9 @@ class SKLearnFeatureExtractionBase:
         # Scikit-learn >= 1.8.0 requires scaler attributes to be numpy arrays (using .astype())
         # which deserializing from JSON natively parses as Python lists. Let's remap them.
         import numpy as np
+
         for k, v in feature_extractor_dict.items():
-            if isinstance(v, list) and k in ['mean_', 'scale_', 'var_', 'data_min_', 'data_max_', 'data_range_']:
+            if isinstance(v, list) and k in ["mean_", "scale_", "var_", "data_min_", "data_max_", "data_range_"]:
                 feature_extractor_dict[k] = np.array(v)
 
         t.__setstate__(feature_extractor_dict)


### PR DESCRIPTION
### What does this PR do?
This PR patches the HF dictionary deserialization logic in `SKLearnFeatureExtractionBase.from_dict` to correctly reconstruct scaler attributes as `numpy.ndarray` objects instead of Python `list` types. 

### Why is this needed?
When using `TimeSeriesPreprocessor.from_pretrained()` to load saved checkpoint from `preprocessor_config.json` generated using `save_pretrained()`, serialized scikit-learn arrays (like `mean_`, `scale_`, and `var_`) are read as `list`s. 

While older `scikit-learn` versions tolerated passing lists, `scikit-learn >= 1.8.0` requires numpy arrays. In newer versions, the `.transform()` method executes `X -= xp.astype(self.mean_, X.dtype)`. Since `self.mean_` was deserialized as a `list` rather than a numpy array, this crashes inference pipelines with:
`AttributeError: 'list' object has no attribute 'astype'`

### Solution
Inside `SKLearnFeatureExtractionBase.from_dict()`, before invoking `__setstate__`, iterate through `.items()` and remap known array parameters (`mean_`, `scale_`, `var_`, `data_min_`, `data_max_`, `data_range_`) back to `np.array`.

### Related Issues
- Resolves #512 (`Relax scikit-learn<1.8 cap — inference path works under sklearn 1.8.0`)