### PR TITLE
PatchTST FM

### DIFF
--- a/tests/models/patchtst_fm/test_modeling_patchtst_fm.py
+++ b/tests/models/patchtst_fm/test_modeling_patchtst_fm.py
@@ -270,7 +270,7 @@ class PatchTSTFMFunctionalTests(unittest.TestCase):
 
         ## Call PatchTST with model
         series = np.expand_dims(sine_wave, axis=0)
-        series = torch.from_numpy(series).float().to("mps")
+        series = torch.from_numpy(series).float().to("cpu")
         with torch.no_grad():
             model_outputs = model(
                 past_values=series,
@@ -286,13 +286,13 @@ class PatchTSTFMFunctionalTests(unittest.TestCase):
         set_seed(seed)
 
         conf = PatchTSTFMConfig(use_pruning=True)
-        model = PatchTSTFMForPrediction(conf).to("mps")
+        model = PatchTSTFMForPrediction(conf).to("cpu")
         set_seed(seed)
         pred_quantiles_forward_model_prune = self._simple_forecast(model)
 
         set_seed(seed)
         conf = PatchTSTFMConfig(use_pruning=False)
-        model = PatchTSTFMForPrediction(conf).to("mps")
+        model = PatchTSTFMForPrediction(conf).to("cpu")
         print(model.device)
         set_seed(seed)
         pred_quantiles_forward_model_no_prune = self._simple_forecast(model)

--- a/tests/models/patchtst_fm/test_modeling_patchtst_fm.py
+++ b/tests/models/patchtst_fm/test_modeling_patchtst_fm.py
@@ -6,6 +6,7 @@
 
 import unittest
 
+import numpy as np
 import torch
 from einops import rearrange
 from parameterized import parameterized
@@ -253,6 +254,45 @@ class PatchTSTFMFunctionalTests(unittest.TestCase):
             stacked_output.shape,
             expected_stacked_shape,
             f"Stacked output has incorrect shape. Expected {expected_stacked_shape}, got {stacked_output.shape}",
+        )
+
+    def _simple_forecast(self, model):
+        pred_len = 24
+        # Generate sine wave data
+        t = np.linspace(0, 4 * np.pi, 200)
+        sine_wave = np.sin(t)
+
+        # Initialize PatchTST Model
+        quantile_levels = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+        model.eval()
+
+        ## Call PatchTST with model
+        series = np.expand_dims(sine_wave, axis=0)
+        series = torch.from_numpy(series).float()
+        with torch.no_grad():
+            model_outputs = model(
+                past_values=series,
+                prediction_length=pred_len,
+                quantile_levels=quantile_levels,
+            )
+        return model_outputs.quantile_outputs.detach().cpu().numpy()
+
+    def test_pruning(
+        self,
+    ):
+        set_seed(1234)
+
+        conf = PatchTSTFMConfig(use_pruning=True)
+        model = PatchTSTFMForPrediction(conf).to("cpu")
+        pred_quantiles_forward_model_prune = self._simple_forecast(model)
+
+        set_seed(1234)
+        conf = PatchTSTFMConfig(use_pruning=False)
+        model = PatchTSTFMForPrediction(conf).to("cpu")
+        pred_quantiles_forward_model_no_prune = self._simple_forecast(model)
+
+        np.testing.assert_allclose(
+            pred_quantiles_forward_model_prune, pred_quantiles_forward_model_no_prune, rtol=1e-6, atol=1e-6
         )
 
 

--- a/tests/models/patchtst_fm/test_modeling_patchtst_fm.py
+++ b/tests/models/patchtst_fm/test_modeling_patchtst_fm.py
@@ -60,6 +60,7 @@ class PatchTSTFMFunctionalTests(unittest.TestCase):
             pretrain_mask_ratio=0.4,
             pretrain_mask_cont=8,
             num_quantile=99,
+            use_pruning=False,
         )
 
         # Initialize model
@@ -216,6 +217,7 @@ class PatchTSTFMFunctionalTests(unittest.TestCase):
             pretrain_mask_ratio=0.4,
             pretrain_mask_cont=8,
             num_quantile=99,
+            use_pruning=False,
         )
 
         # Initialize model
@@ -268,7 +270,7 @@ class PatchTSTFMFunctionalTests(unittest.TestCase):
 
         ## Call PatchTST with model
         series = np.expand_dims(sine_wave, axis=0)
-        series = torch.from_numpy(series).float()
+        series = torch.from_numpy(series).float().to("mps")
         with torch.no_grad():
             model_outputs = model(
                 past_values=series,
@@ -280,19 +282,23 @@ class PatchTSTFMFunctionalTests(unittest.TestCase):
     def test_pruning(
         self,
     ):
-        set_seed(1234)
+        seed = 42
+        set_seed(seed)
 
         conf = PatchTSTFMConfig(use_pruning=True)
-        model = PatchTSTFMForPrediction(conf).to("cpu")
+        model = PatchTSTFMForPrediction(conf).to("mps")
+        set_seed(seed)
         pred_quantiles_forward_model_prune = self._simple_forecast(model)
 
-        set_seed(1234)
+        set_seed(seed)
         conf = PatchTSTFMConfig(use_pruning=False)
-        model = PatchTSTFMForPrediction(conf).to("cpu")
+        model = PatchTSTFMForPrediction(conf).to("mps")
+        print(model.device)
+        set_seed(seed)
         pred_quantiles_forward_model_no_prune = self._simple_forecast(model)
 
         np.testing.assert_allclose(
-            pred_quantiles_forward_model_prune, pred_quantiles_forward_model_no_prune, rtol=1e-6, atol=1e-6
+            pred_quantiles_forward_model_prune, pred_quantiles_forward_model_no_prune, rtol=1e-3, atol=1e-3
         )
 
 

--- a/tests/toolkit/test_time_series_forecasting_pipeline.py
+++ b/tests/toolkit/test_time_series_forecasting_pipeline.py
@@ -85,7 +85,7 @@ def patchtst_fm_dummy_model(conf=None):
         PatchTSTFMForPrediction: A PatchTST-FM model instance for testing.
     """
     if conf is None:
-        conf = PatchTSTFMConfig()
+        conf = PatchTSTFMConfig(use_pruning=False)
     model = PatchTSTFMForPrediction(conf)
 
     return model

--- a/tests/toolkit/test_time_series_forecasting_pipeline.py
+++ b/tests/toolkit/test_time_series_forecasting_pipeline.py
@@ -326,7 +326,6 @@ def test_ttm_native_probabilistc_forecasting_pipeline(etth_data_base):
     )
     forecasts = forecast_pipeline(test_data)
 
-    print(forecasts.keys())
     assert len(forecasts[f"{target_columns[0]}"]) == pfl
     for i in quantile_levels:
         assert len(forecasts[f"{target_columns[0]}_prediction_q{i}"]) == pfl
@@ -368,7 +367,6 @@ def test_ttm_decomposed_native_probabilistc_forecasting_pipeline(etth_data_base)
     )
     forecasts = forecast_pipeline(test_data)
 
-    print(forecasts.keys())
     assert len(forecasts[f"{target_columns[0]}"]) == pfl
     for i in quantile_levels:
         assert len(forecasts[f"{target_columns[0]}_prediction_q{i}"]) == pfl
@@ -697,13 +695,17 @@ def test_expanding_context(patchtst_fm_dummy_model):
 
     for ix_q, q in enumerate(quantile_levels):
         np.testing.assert_allclose(
-            np.mean(np.abs(pred_quantiles_pipeline[ix_q, :] - pred_quantiles_forward_model[ix_q, :])),
-            0,
+            pred_quantiles_pipeline[ix_q, :],
+            pred_quantiles_forward_model[ix_q, :],
             err_msg=f"Difference in quantile {q} should be zero (pipeline vs. direct tensor).",
+            rtol=1e-6,
+            atol=1e-6,
         )
 
         np.testing.assert_allclose(
-            np.mean(np.abs(pred_quantiles_pipeline[ix_q, :] - pred_quantiles_forward_model_2[ix_q, :])),
-            0,
+            pred_quantiles_pipeline[ix_q, :],
+            pred_quantiles_forward_model_2[ix_q, :],
             err_msg=f"Difference in quantile {q} should be zero (pipeline vs. direct list).",
+            rtol=1e-6,
+            atol=1e-6,
         )

--- a/tsfm_public/models/patchtst_fm/basic.py
+++ b/tsfm_public/models/patchtst_fm/basic.py
@@ -253,22 +253,12 @@ class TransformerBlock(nn.Module):
             raise ValueError(f"Unsupported MLP type: {mlp_type}")
         self.dropout = nn.Dropout(dropout)
 
-    def forward(self, x, attn_mask=None, pruning_flag=False, i=0):
+    def forward(self, x, attn_mask=None):
         if self.norm_first:
             x_norm1 = self.norm1(x)
-            # if pruning_flag:
-            #     torch.save(x_norm1, f"x_norm1_{i}.out")
-            # else:
-            #     z = torch.load(f"x_norm1_{i}.out")
-            #     print(f"Tx norm1 {i}", torch.sum(torch.abs(x_norm1[:, -21:, :] - z)))
             x_self_attn = self.attn(x_norm1, attn_mask)
-            # if pruning_flag:
-            #     torch.save(x_self_attn, f"x_self_attn_{i}.out")
-            # else:
-            #     z = torch.load(f"x_self_attn_{i}.out")
-            #     print(f"Tx self_attn {i}", torch.sum(torch.abs(x_self_attn[:, -21:, :] - z)))
 
-            x = x + x_self_attn  # x + self.attn(x_norm1, attn_mask)
+            x = x + x_self_attn
             x = x + self.dropout(self.mlp(self.norm2(x)))
         else:
             x = self.norm1(x + self.attn(x, attn_mask))

--- a/tsfm_public/models/patchtst_fm/basic.py
+++ b/tsfm_public/models/patchtst_fm/basic.py
@@ -110,7 +110,9 @@ class Attention(nn.Module):
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
         if x.ndim == 3:
             B, N, C = x.shape
-            qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, self.head_dim).permute(2, 0, 3, 1, 4)
+            qkv = (
+                self.qkv(x).reshape(B, N, 3, self.num_heads, self.head_dim).permute(2, 0, 3, 1, 4)
+            )  # 3 x B x num_heads x N (num_patches) x head_dim
             q, k, v = qkv.unbind(0)  # (B, num_heads, N, head_dim)
             q, k = self.q_norm(q), self.k_norm(k)
             x = F.scaled_dot_product_attention(
@@ -119,7 +121,7 @@ class Attention(nn.Module):
                 v,
                 dropout_p=self.attn_drop.p if self.training else 0.0,
                 attn_mask=attn_mask,
-            )
+            )  # (B, num_heads, N, head_dim)
             x = x.transpose(1, 2).reshape(B, N, C)
         elif x.ndim == 4:
             B, M, N, C = x.shape

--- a/tsfm_public/models/patchtst_fm/basic.py
+++ b/tsfm_public/models/patchtst_fm/basic.py
@@ -3,6 +3,7 @@ from typing import Optional, Type
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from torch.nn.attention import SDPBackend, sdpa_kernel
 
 
 def make_attn_mask(query_pad: torch.Tensor, key_pad: torch.Tensor) -> torch.Tensor:
@@ -115,6 +116,7 @@ class Attention(nn.Module):
             )  # 3 x B x num_heads x N (num_patches) x head_dim
             q, k, v = qkv.unbind(0)  # (B, num_heads, N, head_dim)
             q, k = self.q_norm(q), self.k_norm(k)
+            # with sdpa_kernel(SDPBackend.MATH):
             x = F.scaled_dot_product_attention(
                 q,
                 k,
@@ -129,6 +131,7 @@ class Attention(nn.Module):
             q, k, v = qkv.unbind(0)  # (B, num_heads, M, N, head_dim)
             q, k = self.q_norm(q), self.k_norm(k)
             # print('q', q.shape, 'k', k.shape, 'v', v.shape, 'attn_mask', attn_mask.shape if attn_mask is not None else "None")
+            # with sdpa_kernel(SDPBackend.MATH):
             x = F.scaled_dot_product_attention(
                 q,
                 k,
@@ -251,9 +254,22 @@ class TransformerBlock(nn.Module):
             raise ValueError(f"Unsupported MLP type: {mlp_type}")
         self.dropout = nn.Dropout(dropout)
 
-    def forward(self, x, attn_mask=None):
+    def forward(self, x, attn_mask=None, pruning_flag=False, i=0):
         if self.norm_first:
-            x = x + self.attn(self.norm1(x), attn_mask)
+            x_norm1 = self.norm1(x)
+            # if pruning_flag:
+            #     torch.save(x_norm1, f"x_norm1_{i}.out")
+            # else:
+            #     z = torch.load(f"x_norm1_{i}.out")
+            #     print(f"Tx norm1 {i}", torch.sum(torch.abs(x_norm1[:, -21:, :] - z)))
+            x_self_attn = self.attn(x_norm1, attn_mask)
+            # if pruning_flag:
+            #     torch.save(x_self_attn, f"x_self_attn_{i}.out")
+            # else:
+            #     z = torch.load(f"x_self_attn_{i}.out")
+            #     print(f"Tx self_attn {i}", torch.sum(torch.abs(x_self_attn[:, -21:, :] - z)))
+
+            x = x + x_self_attn  # x + self.attn(x_norm1, attn_mask)
             x = x + self.dropout(self.mlp(self.norm2(x)))
         else:
             x = self.norm1(x + self.attn(x, attn_mask))

--- a/tsfm_public/models/patchtst_fm/basic.py
+++ b/tsfm_public/models/patchtst_fm/basic.py
@@ -3,7 +3,6 @@ from typing import Optional, Type
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.nn.attention import SDPBackend, sdpa_kernel
 
 
 def make_attn_mask(query_pad: torch.Tensor, key_pad: torch.Tensor) -> torch.Tensor:

--- a/tsfm_public/models/patchtst_fm/configuration_patchtst_fm.py
+++ b/tsfm_public/models/patchtst_fm/configuration_patchtst_fm.py
@@ -18,7 +18,6 @@ class PatchTSTFMConfig(PretrainedConfig):
         "num_hidden_layers": "n_layer",
     }
 
-    # has_no_defaults_at_init = True
     def __init__(
         self,
         context_length: int = 8192,
@@ -31,8 +30,28 @@ class PatchTSTFMConfig(PretrainedConfig):
         pretrain_mask_ratio: float = 0.4,
         pretrain_mask_cont: int = 8,
         num_quantile: int = 99,
+        use_pruning: bool = True,
         **kwargs,
     ):
+        """Configuration for PatchTST-FM.
+
+        Args:
+            context_length (int, optional): Number of timesteps for the context, includes both historical and predicted
+                timesteps. Defaults to 8192.
+            prediction_length (int, optional): Number of timesteps in the prediction output. Defaults to 64.
+            d_patch (int, optional): Size of patches. Defaults to 16. Context length must be divisible by d_patch.
+            d_model (int, optional): Size of patches after projection before feeding into the transformer layers. Defaults to
+                384.
+            n_head (int, optional): Number of attention heads. Defaults to 6.
+            n_layer (int, optional): Number of transformer layers. Defaults to 6.
+            norm_first (bool, optional): If true, normalization is done first in the transformer layers. Defaults to True.
+            pretrain_mask_ratio (float, optional): _description_. Defaults to 0.4.
+            pretrain_mask_cont (int, optional): Number of contiguous patches to mask during pretraining. Defaults to 8.
+            num_quantile (int, optional): Number of quantiles to include in the quantile outputs. Defaults to 99.
+            use_pruning (bool, optional): When the input tensor has context less than the configured context_length, it will
+                be padded. The leading padding can be pruned to reduce unneccessary computation if value of the earlier
+                indices are not needed. Defaults to True.
+        """
         self.context_length = context_length
         self.prediction_length = prediction_length
         self.d_patch = d_patch

--- a/tsfm_public/models/patchtst_fm/configuration_patchtst_fm.py
+++ b/tsfm_public/models/patchtst_fm/configuration_patchtst_fm.py
@@ -63,6 +63,7 @@ class PatchTSTFMConfig(PretrainedConfig):
         self.pretrain_mask_ratio = pretrain_mask_ratio
         self.pretrain_mask_cont = pretrain_mask_cont
         self.num_quantile = num_quantile
+        self.use_pruning = use_pruning
 
         if num_quantile % 9 == 0:
             quantiles = [i / (self.num_quantile + 1) for i in range(1, self.num_quantile + 1)]

--- a/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
+++ b/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
@@ -32,7 +32,6 @@ class LearnedPositionalEmbedding(nn.Module):
         self.type = type
 
     def forward(self, x, offset: Optional[int] = 0):
-        logger.info(f"LearnedPositionalEmbedding offset is {offset}")
         positions = torch.arange(start=offset, end=x.size(-2) + offset, device=x.device).unsqueeze(0)
         pe = self.embedding(positions)
         if x.ndim == 4:
@@ -520,7 +519,6 @@ class PatchTSTFMForPrediction(PatchTSTFMPreTrainedModel):
         pad_mask = rearrange(pad_mask, "B T N -> (B N) T")
 
         with torch.autocast(device_type=self._device, dtype=self._precision, enabled=True):
-            logger.info(f"Calling backbone with context_length = {context_length}")
             model_output = self.backbone(
                 inputs=inputs,
                 pred_mask=pred_mask,

--- a/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
+++ b/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
@@ -156,7 +156,7 @@ class PatchTSTFMModel(PatchTSTFMPreTrainedModel):
         mask_patch = ts_mask.reshape(B, self.config.n_patch, self.config.d_patch)
         pad_patch_mask = pad_mask.reshape(B, self.config.n_patch, self.config.d_patch).float().mean(dim=-1).gt(0.9)
 
-        q_pred, q_raw = self.decode(x=x_patch, mask=mask_patch.float(), t_pad_mask=pad_patch_mask)
+        q_pred, q_raw = self.decode(x=x_patch, mask=mask_patch, t_pad_mask=pad_patch_mask)
         q_pred = q_pred.permute(0, 2, 3, 1)
 
         B, N, D, Q = q_pred.shape
@@ -178,17 +178,34 @@ class PatchTSTFMModel(PatchTSTFMPreTrainedModel):
     def decode(self, x, mask, t_pad_mask=None):
         B, N, D = x.shape
         # x = self.in_layer(torch.cat([x, t, 1 - mask], dim=-1))
-        x = self.in_layer(torch.cat([x, 1 - mask], dim=-1))
+        x = self.in_layer(torch.cat([x, ~mask], dim=-1))  # B x n_patch X d_model
         pad_attn_mask = make_attn_mask(t_pad_mask, t_pad_mask).unsqueeze(1)
 
-        x = self.pos_embed(x)
+        # x: bs x num_patches x 2*seq_len
+        x = self.pos_embed(x)  # bs x num_patches x 2*seq_len
+
+        # determine the ealiest index where the padding ends
+        hard_cutoff = True
+        if hard_cutoff:
+            idx = t_pad_mask.to(torch.float16).argmin(dim=1).min()
+            x = x[:, idx:]
+        else:
+            idx = 0
+
         for block in self.blocks:
-            x = block(x, pad_attn_mask)
+            x = block(x, pad_attn_mask[:, :, idx:, idx:])
+        Np = x.shape[1]
+
         x = self.out_layer(x)
-        q_raw = x.reshape(B, N, self.config.num_quantile + 1, self.config.d_patch).permute(0, 2, 1, 3)
+        q_raw = x.reshape(B, Np, self.config.num_quantile + 1, self.config.d_patch).permute(0, 2, 1, 3)
         q = q_raw[:, 0, :, :].unsqueeze(1) + torch.cumsum(
             F.softplus(q_raw[:, 1:, :, :]) / self.config.num_quantile, dim=1
         )
+
+        # pad to get back to expected shape
+        if hard_cutoff:
+            q = F.pad(q, (0, 0, idx, 0), mode="constant", value=0.0)
+
         return q, q_raw
 
 

--- a/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
+++ b/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
@@ -157,8 +157,10 @@ class PatchTSTFMModel(PatchTSTFMPreTrainedModel):
         mask_patch = ts_mask.reshape(B, self.config.n_patch, self.config.d_patch)
         pad_patch_mask = pad_mask.reshape(B, self.config.n_patch, self.config.d_patch).float().mean(dim=-1).gt(0.9)
 
-        # determine the ealiest index where the padding ends
-        if context_length is not None and self.config.use_pruning:
+        # determine the earliest index where the padding ends
+        if context_length == self.config.context_length:
+            idx = 0
+        elif context_length is not None and self.config.use_pruning:
             idx = (self.config.context_length - context_length) // self.config.d_patch
             x_patch = x_patch[:, idx:]
             mask_patch = mask_patch[:, idx:]

--- a/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
+++ b/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
@@ -293,6 +293,8 @@ class PatchTSTFMForPrediction(PatchTSTFMPreTrainedModel):
         self.config = config
         self.backbone = PatchTSTFMModel(config)
 
+        self._autocast = torch.cuda.is_available()
+
         self._precision = (
             torch.bfloat16
             if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 8
@@ -540,17 +542,17 @@ class PatchTSTFMForPrediction(PatchTSTFMPreTrainedModel):
         miss_mask = rearrange(miss_mask, "B T N -> (B N) T")
         pad_mask = rearrange(pad_mask, "B T N -> (B N) T")
 
-        # with torch.autocast(device_type=self._device, dtype=self._precision, enabled=True):
-        model_output = self.backbone(
-            inputs=inputs,
-            pred_mask=pred_mask,
-            miss_mask=miss_mask,
-            pad_mask=pad_mask,
-            return_loss=False,
-            output_hidden_states=output_hidden_states,
-            context_length=context,
-        )
-        outputs = model_output.quantile_outputs
+        with torch.autocast(device_type=self._device, dtype=self._precision, enabled=self._autocast):
+            model_output = self.backbone(
+                inputs=inputs,
+                pred_mask=pred_mask,
+                miss_mask=miss_mask,
+                pad_mask=pad_mask,
+                return_loss=False,
+                output_hidden_states=output_hidden_states,
+                context_length=context,
+            )
+            outputs = model_output.quantile_outputs
 
         outputs = outputs.permute(0, 2, 1)
         outputs = self.backbone.norm_fn.inverse_transform(outputs)
@@ -716,16 +718,16 @@ class PatchTSTFMForPrediction(PatchTSTFMPreTrainedModel):
         miss_mask = rearrange(miss_mask, "B T N -> (B N) T")
         pad_mask = rearrange(pad_mask, "B T N -> (B N) T")
 
-        # with torch.autocast(device_type=self._device, dtype=self._precision, enabled=True):
-        model_output = self.backbone(
-            inputs=inputs,
-            pred_mask=pred_mask,
-            miss_mask=miss_mask,
-            pad_mask=pad_mask,
-            return_loss=False,
-            output_hidden_states=output_hidden_states,
-        )
-        outputs = model_output.quantile_outputs
+        with torch.autocast(device_type=self._device, dtype=self._precision, enabled=self._autocast):
+            model_output = self.backbone(
+                inputs=inputs,
+                pred_mask=pred_mask,
+                miss_mask=miss_mask,
+                pad_mask=pad_mask,
+                return_loss=False,
+                output_hidden_states=output_hidden_states,
+            )
+            outputs = model_output.quantile_outputs
 
         outputs = outputs.permute(0, 2, 1)
         outputs = self.backbone.norm_fn.inverse_transform(outputs)

--- a/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
+++ b/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
@@ -195,35 +195,13 @@ class PatchTSTFMModel(PatchTSTFMPreTrainedModel):
         B, N, D = x.shape
         # x = self.in_layer(torch.cat([x, t, 1 - mask], dim=-1))
         x = self.in_layer(torch.cat([x, ~mask], dim=-1))  # B x n_patch X d_model
-        # if offset != 0:  # comparison 0
-        #     torch.save(x, "x_in_layer.out")
-        # else:
-        #     z = torch.load("x_in_layer.out")
-        #     print("1: ", torch.sum(torch.abs(x[..., -21:, :] - z)))
         pad_attn_mask = make_attn_mask(t_pad_mask, t_pad_mask).unsqueeze(1)
-        # if offset != 0:
-        #     torch.save(pad_attn_mask, "pad_attn_mask.out")
-        # else:
-        #     z = torch.load("pad_attn_mask.out")
-        #     print("2: ", torch.sum(torch.abs(pad_attn_mask[..., -21:, -21:] - z)))
-        # x: bs x num_patches x 2*seq_len
         x = self.pos_embed(x, offset=offset)  # bs x num_patches x 2*seq_len
-        # if offset != 0:
-        #     torch.save(x, "x_pos_embed.out")
-        # else:
-        #     z = torch.load("x_pos_embed.out")
-        #     print("3: ", torch.sum(torch.abs(x[..., -21:, :] - z)))
 
         for i, block in enumerate(self.blocks):
-            # x = torch.where(t_pad_mask.unsqueeze(-1).expand_as(x), torch.zeros_like(x), x)
-            x = block(x, pad_attn_mask, pruning_flag=offset != 0, i=i)
+            x = block(x, pad_attn_mask)
 
         x = self.out_layer(x)
-        # if offset != 0:
-        #     torch.save(x, "x_out_layer.out")
-        # else:
-        #     z = torch.load("x_out_layer.out")
-        #     print("4: ", torch.sum(torch.abs(x[..., -21:, :] - z)))
         q_raw = x.reshape(B, N, self.config.num_quantile + 1, self.config.d_patch).permute(0, 2, 1, 3)
         q = q_raw[:, 0, :, :].unsqueeze(1) + torch.cumsum(
             F.softplus(q_raw[:, 1:, :, :]) / self.config.num_quantile, dim=1

--- a/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
+++ b/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
@@ -158,7 +158,7 @@ class PatchTSTFMModel(PatchTSTFMPreTrainedModel):
         pad_patch_mask = pad_mask.reshape(B, self.config.n_patch, self.config.d_patch).float().mean(dim=-1).gt(0.9)
 
         # determine the ealiest index where the padding ends
-        if context_length is not None:
+        if context_length is not None and self.config.use_pruning:
             idx = (self.config.context_length - context_length) // self.config.d_patch
             x_patch = x_patch[:, idx:]
             mask_patch = mask_patch[:, idx:]
@@ -173,7 +173,7 @@ class PatchTSTFMModel(PatchTSTFMPreTrainedModel):
         q_pred = q_pred.reshape(B, N * D, Q)
 
         # pad back to the original length
-        if context_length is not None:
+        if context_length is not None and self.config.use_pruning:
             q_pred = F.pad(q_pred, (0, 0, idx * D, 0), value=0.0)
 
         if output_hidden_states:

--- a/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
+++ b/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
@@ -150,7 +150,7 @@ class PatchTSTFMModel(PatchTSTFMPreTrainedModel):
         B, T = x.shape
         ts_mask = pred_mask | pad_mask | miss_mask
 
-        x_target = self.norm_fn.fit_transform(x, mask=pred_mask | pad_mask | miss_mask)
+        x_target = self.norm_fn.fit_transform(x, mask=ts_mask)
         x_input = torch.where(ts_mask, torch.zeros_like(x_target), x_target)
 
         x_patch = x_input.reshape(B, self.config.n_patch, self.config.d_patch)
@@ -195,15 +195,35 @@ class PatchTSTFMModel(PatchTSTFMPreTrainedModel):
         B, N, D = x.shape
         # x = self.in_layer(torch.cat([x, t, 1 - mask], dim=-1))
         x = self.in_layer(torch.cat([x, ~mask], dim=-1))  # B x n_patch X d_model
+        # if offset != 0:  # comparison 0
+        #     torch.save(x, "x_in_layer.out")
+        # else:
+        #     z = torch.load("x_in_layer.out")
+        #     print("1: ", torch.sum(torch.abs(x[..., -21:, :] - z)))
         pad_attn_mask = make_attn_mask(t_pad_mask, t_pad_mask).unsqueeze(1)
-
+        # if offset != 0:
+        #     torch.save(pad_attn_mask, "pad_attn_mask.out")
+        # else:
+        #     z = torch.load("pad_attn_mask.out")
+        #     print("2: ", torch.sum(torch.abs(pad_attn_mask[..., -21:, -21:] - z)))
         # x: bs x num_patches x 2*seq_len
         x = self.pos_embed(x, offset=offset)  # bs x num_patches x 2*seq_len
+        # if offset != 0:
+        #     torch.save(x, "x_pos_embed.out")
+        # else:
+        #     z = torch.load("x_pos_embed.out")
+        #     print("3: ", torch.sum(torch.abs(x[..., -21:, :] - z)))
 
-        for block in self.blocks:
-            x = block(x, pad_attn_mask)
+        for i, block in enumerate(self.blocks):
+            # x = torch.where(t_pad_mask.unsqueeze(-1).expand_as(x), torch.zeros_like(x), x)
+            x = block(x, pad_attn_mask, pruning_flag=offset != 0, i=i)
 
         x = self.out_layer(x)
+        # if offset != 0:
+        #     torch.save(x, "x_out_layer.out")
+        # else:
+        #     z = torch.load("x_out_layer.out")
+        #     print("4: ", torch.sum(torch.abs(x[..., -21:, :] - z)))
         q_raw = x.reshape(B, N, self.config.num_quantile + 1, self.config.d_patch).permute(0, 2, 1, 3)
         q = q_raw[:, 0, :, :].unsqueeze(1) + torch.cumsum(
             F.softplus(q_raw[:, 1:, :, :]) / self.config.num_quantile, dim=1

--- a/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
+++ b/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
@@ -540,17 +540,17 @@ class PatchTSTFMForPrediction(PatchTSTFMPreTrainedModel):
         miss_mask = rearrange(miss_mask, "B T N -> (B N) T")
         pad_mask = rearrange(pad_mask, "B T N -> (B N) T")
 
-        with torch.autocast(device_type=self._device, dtype=self._precision, enabled=True):
-            model_output = self.backbone(
-                inputs=inputs,
-                pred_mask=pred_mask,
-                miss_mask=miss_mask,
-                pad_mask=pad_mask,
-                return_loss=False,
-                output_hidden_states=output_hidden_states,
-                context_length=context,
-            )
-            outputs = model_output.quantile_outputs
+        # with torch.autocast(device_type=self._device, dtype=self._precision, enabled=True):
+        model_output = self.backbone(
+            inputs=inputs,
+            pred_mask=pred_mask,
+            miss_mask=miss_mask,
+            pad_mask=pad_mask,
+            return_loss=False,
+            output_hidden_states=output_hidden_states,
+            context_length=context,
+        )
+        outputs = model_output.quantile_outputs
 
         outputs = outputs.permute(0, 2, 1)
         outputs = self.backbone.norm_fn.inverse_transform(outputs)
@@ -716,16 +716,16 @@ class PatchTSTFMForPrediction(PatchTSTFMPreTrainedModel):
         miss_mask = rearrange(miss_mask, "B T N -> (B N) T")
         pad_mask = rearrange(pad_mask, "B T N -> (B N) T")
 
-        with torch.autocast(device_type=self._device, dtype=self._precision, enabled=True):
-            model_output = self.backbone(
-                inputs=inputs,
-                pred_mask=pred_mask,
-                miss_mask=miss_mask,
-                pad_mask=pad_mask,
-                return_loss=False,
-                output_hidden_states=output_hidden_states,
-            )
-            outputs = model_output.quantile_outputs
+        # with torch.autocast(device_type=self._device, dtype=self._precision, enabled=True):
+        model_output = self.backbone(
+            inputs=inputs,
+            pred_mask=pred_mask,
+            miss_mask=miss_mask,
+            pad_mask=pad_mask,
+            return_loss=False,
+            output_hidden_states=output_hidden_states,
+        )
+        outputs = model_output.quantile_outputs
 
         outputs = outputs.permute(0, 2, 1)
         outputs = self.backbone.norm_fn.inverse_transform(outputs)

--- a/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
+++ b/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
@@ -31,8 +31,9 @@ class LearnedPositionalEmbedding(nn.Module):
         self.embedding = nn.Embedding(max_len, d_model)
         self.type = type
 
-    def forward(self, x):
-        positions = torch.arange(x.size(-2), device=x.device).unsqueeze(0)
+    def forward(self, x, offset: Optional[int] = 0):
+        logger.info(f"LearnedPositionalEmbedding offset is {offset}")
+        positions = torch.arange(start=offset, end=x.size(-2) + offset, device=x.device).unsqueeze(0)
         pe = self.embedding(positions)
         if x.ndim == 4:
             pe = pe.unsqueeze(1)
@@ -134,6 +135,7 @@ class PatchTSTFMModel(PatchTSTFMPreTrainedModel):
         output_hidden_states: Optional[bool] = False,
         return_loss: bool = True,
         return_dict: Optional[bool] = None,
+        context_length: Optional[int] = None,
         # **kwargs,
     ) -> PatchTSTFMModelOutput:
         x = inputs  # .to(self.device)
@@ -156,11 +158,24 @@ class PatchTSTFMModel(PatchTSTFMPreTrainedModel):
         mask_patch = ts_mask.reshape(B, self.config.n_patch, self.config.d_patch)
         pad_patch_mask = pad_mask.reshape(B, self.config.n_patch, self.config.d_patch).float().mean(dim=-1).gt(0.9)
 
-        q_pred, q_raw = self.decode(x=x_patch, mask=mask_patch, t_pad_mask=pad_patch_mask)
+        # determine the ealiest index where the padding ends
+        if context_length is not None:
+            idx = (self.config.context_length - context_length) // self.config.d_patch
+            x_patch = x_patch[:, idx:]
+            mask_patch = mask_patch[:, idx:]
+            pad_patch_mask = pad_patch_mask[:, idx:]
+        else:
+            idx = 0
+
+        q_pred, q_raw = self.decode(x=x_patch, mask=mask_patch, t_pad_mask=pad_patch_mask, offset=idx)
         q_pred = q_pred.permute(0, 2, 3, 1)
 
         B, N, D, Q = q_pred.shape
         q_pred = q_pred.reshape(B, N * D, Q)
+
+        # pad back to the original length
+        if context_length is not None:
+            q_pred = F.pad(q_pred, (0, 0, idx * D, 0), value=0.0)
 
         if output_hidden_states:
             hidden_states = q_raw.reshape(B, N * D, Q)
@@ -175,36 +190,23 @@ class PatchTSTFMModel(PatchTSTFMPreTrainedModel):
             hidden_states=hidden_states,
         )
 
-    def decode(self, x, mask, t_pad_mask=None):
+    def decode(self, x, mask, t_pad_mask=None, offset: Optional[int] = 0):
         B, N, D = x.shape
         # x = self.in_layer(torch.cat([x, t, 1 - mask], dim=-1))
         x = self.in_layer(torch.cat([x, ~mask], dim=-1))  # B x n_patch X d_model
         pad_attn_mask = make_attn_mask(t_pad_mask, t_pad_mask).unsqueeze(1)
 
         # x: bs x num_patches x 2*seq_len
-        x = self.pos_embed(x)  # bs x num_patches x 2*seq_len
-
-        # determine the ealiest index where the padding ends
-        hard_cutoff = True
-        if hard_cutoff:
-            idx = t_pad_mask.to(torch.float16).argmin(dim=1).min()
-            x = x[:, idx:]
-        else:
-            idx = 0
+        x = self.pos_embed(x, offset=offset)  # bs x num_patches x 2*seq_len
 
         for block in self.blocks:
-            x = block(x, pad_attn_mask[:, :, idx:, idx:])
-        Np = x.shape[1]
+            x = block(x, pad_attn_mask)
 
         x = self.out_layer(x)
-        q_raw = x.reshape(B, Np, self.config.num_quantile + 1, self.config.d_patch).permute(0, 2, 1, 3)
+        q_raw = x.reshape(B, N, self.config.num_quantile + 1, self.config.d_patch).permute(0, 2, 1, 3)
         q = q_raw[:, 0, :, :].unsqueeze(1) + torch.cumsum(
             F.softplus(q_raw[:, 1:, :, :]) / self.config.num_quantile, dim=1
         )
-
-        # pad to get back to expected shape
-        if hard_cutoff:
-            q = F.pad(q, (0, 0, idx, 0), mode="constant", value=0.0)
 
         return q, q_raw
 
@@ -518,6 +520,7 @@ class PatchTSTFMForPrediction(PatchTSTFMPreTrainedModel):
         pad_mask = rearrange(pad_mask, "B T N -> (B N) T")
 
         with torch.autocast(device_type=self._device, dtype=self._precision, enabled=True):
+            logger.info(f"Calling backbone with context_length = {context_length}")
             model_output = self.backbone(
                 inputs=inputs,
                 pred_mask=pred_mask,
@@ -525,6 +528,7 @@ class PatchTSTFMForPrediction(PatchTSTFMPreTrainedModel):
                 pad_mask=pad_mask,
                 return_loss=False,
                 output_hidden_states=output_hidden_states,
+                context_length=context,
             )
             outputs = model_output.quantile_outputs
 

--- a/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
+++ b/tsfm_public/models/patchtst_fm/modeling_patchtst_fm.py
@@ -656,7 +656,7 @@ class PatchTSTFMForPrediction(PatchTSTFMPreTrainedModel):
                 pad_mask.append(F.pad(pad_mask_i, (0, 0, left_pad, 0), mode="constant", value=True))
                 miss_mask.append(F.pad(miss_mask_i, (0, 0, left_pad, 0), mode="constant", value=False))
                 time_index.append(F.pad(time_index_i, (left_pad, 0), mode="constant", value=-1))
-                ts_ends.append(torch.tensor([left_pad, left_pad + sample_len], dtype=torch.int))
+                ts_ends.append(torch.tensor([left_pad, left_pad + sample_len], dtype=torch.int, device=device))
                 sample_lengths.append(sample_len)
             else:  # subsample
                 inputs.append(
@@ -700,7 +700,7 @@ class PatchTSTFMForPrediction(PatchTSTFMPreTrainedModel):
                         mode="nearest",
                     ).squeeze()
                 )
-                ts_ends.append(torch.tensor([0, self.config.context_length], dtype=torch.int))
+                ts_ends.append(torch.tensor([0, self.config.context_length], dtype=torch.int, device=device))
                 sample_lengths.append(sample_len)
 
         inputs = torch.stack(inputs, dim=0)


### PR DESCRIPTION
Enable pruning of padded context during attention computation. This provides significant speed up based on our testing.